### PR TITLE
feat: add footer header layout and screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.4.3"
       },
       "devDependencies": {
         "@types/react": "^18.0.17",
@@ -548,6 +549,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1858,6 +1867,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2546,6 +2585,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -3353,6 +3397,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "requires": {
+        "@remix-run/router": "1.0.3"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "requires": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
+      }
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.3"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,37 +1,27 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
+import React from 'react'
+
 import './App.css'
-import ExampleContainer from './Components/ExampleComponent/ExampleContainer'
+
+import Layout from './Components/Layout'
+import HomeScreen from './Screens/HomeScreen'
+import SecondScreen from './Screens/SecondScreen'
+// import NotFoundScreen from './Screens/404Screen'
+
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
 function App() {
-  const [count, setCount] = useState(0)
 
   return (
-    <div className="App">
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src="/vite.svg" className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://reactjs.org" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1 className="text-3xl font-bold underline">Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <ExampleContainer/>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-
-    </div>
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route path={'/'} element={ <HomeScreen /> } />
+          <Route path={'/news'} element={ <SecondScreen /> } />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
   )
+  
 }
 
 export default App

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Footer = () => {
+  return (
+    <div>Footer</div>
+  )
+}
+
+export default Footer

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Header = () => {
+  return (
+    <div>Header</div>
+  )
+}
+
+export default Header

--- a/src/Components/Layout/Layout.jsx
+++ b/src/Components/Layout/Layout.jsx
@@ -1,0 +1,14 @@
+import Header from '../Header/Header'
+import Footer from '../Footer/Footer'
+
+const Layout = ({ children }) => {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  )
+}
+
+export default Layout

--- a/src/Components/Layout/index.js
+++ b/src/Components/Layout/index.js
@@ -1,0 +1,2 @@
+import Layout from './Layout'
+export default Layout

--- a/src/Components/SecondExampleComponent/SecondComponent.jsx
+++ b/src/Components/SecondExampleComponent/SecondComponent.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const SecondComponent = () => {
+  return (
+    <h1>News</h1>
+  )
+}
+
+export default SecondComponent

--- a/src/Screens/404Screen.jsx
+++ b/src/Screens/404Screen.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const NotFoundScreen = () => {
+  return (
+    <>
+      <h1>404 Not Found</h1>
+    </>
+  );
+};
+
+export default NotFoundScreen

--- a/src/Screens/HomeScreen.jsx
+++ b/src/Screens/HomeScreen.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ExampleContainer from '../Components/ExampleComponent/ExampleContainer'
+
+const HomeScreen = () => {
+  return (
+    <>
+      <ExampleContainer />
+    </>
+  );
+};
+
+export default HomeScreen

--- a/src/Screens/SecondScreen.jsx
+++ b/src/Screens/SecondScreen.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import SecondComponent from '../Components/SecondExampleComponent/SecondComponent'
+
+const SecondScreen = () => {
+  return (
+    <>
+      <SecondComponent/>
+    </>
+  );
+};
+
+export default SecondScreen

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+const root = ReactDOM.createRoot(document.getElementById("root"))
+root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-)
+);


### PR DESCRIPTION
Setup React Router
Al ingresar a la ruta base “/“, mostrar un componente
Al ingresar a una ruta diferente (por ejemplo “/news”), mostrar otro componente 

Generé un layout con header y footer y un { children } donde renderizar todo el contenido dinámico
Generé Screens para dichas situaciones -> Home, News, NotFound

Falta agregar la forma de redirigir a la Screen 404 cuando no se pegue en alguna url válida